### PR TITLE
Remove redundant php closing tag

### DIFF
--- a/contrib/cssgen.php
+++ b/contrib/cssgen.php
@@ -463,4 +463,4 @@ it includes most of the basic information.</p>';
     make_footer();
 }
 
-?>
+

--- a/geshi.php
+++ b/geshi.php
@@ -4772,4 +4772,3 @@ if (!function_exists('geshi_highlight')) {
     }
 }
 
-?>

--- a/geshi/6502acme.php
+++ b/geshi/6502acme.php
@@ -227,4 +227,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/6502kickass.php
+++ b/geshi/6502kickass.php
@@ -238,4 +238,3 @@ $language_data = array (
         ),
 );
 
-?>

--- a/geshi/6502tasm.php
+++ b/geshi/6502tasm.php
@@ -186,4 +186,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/68000devpac.php
+++ b/geshi/68000devpac.php
@@ -165,4 +165,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/abap.php
+++ b/geshi/abap.php
@@ -1406,4 +1406,3 @@ $language_data = array(
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/actionscript.php
+++ b/geshi/actionscript.php
@@ -194,4 +194,3 @@ $language_data = array (
     'HIGHLIGHT_STRICT_BLOCK' => array()
 );
 
-?>

--- a/geshi/actionscript3.php
+++ b/geshi/actionscript3.php
@@ -470,4 +470,3 @@ $language_data = array (
     'HIGHLIGHT_STRICT_BLOCK' => array()
 );
 
-?>

--- a/geshi/ada.php
+++ b/geshi/ada.php
@@ -132,4 +132,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/algol68.php
+++ b/geshi/algol68.php
@@ -326,4 +326,3 @@ $language_data = array(
 );
 
 unset($a68);
-?>

--- a/geshi/apache.php
+++ b/geshi/apache.php
@@ -480,4 +480,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/applescript.php
+++ b/geshi/applescript.php
@@ -154,4 +154,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/apt_sources.php
+++ b/geshi/apt_sources.php
@@ -152,4 +152,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/arm.php
+++ b/geshi/arm.php
@@ -3315,4 +3315,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/asm.php
+++ b/geshi/asm.php
@@ -600,4 +600,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/asp.php
+++ b/geshi/asp.php
@@ -161,4 +161,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/autoconf.php
+++ b/geshi/autoconf.php
@@ -509,4 +509,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/autohotkey.php
+++ b/geshi/autohotkey.php
@@ -370,4 +370,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/autoit.php
+++ b/geshi/autoit.php
@@ -1172,4 +1172,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/avisynth.php
+++ b/geshi/avisynth.php
@@ -191,4 +191,4 @@ $language_data = array (
         ),
     'TAB_WIDTH' => 4
 );
-?>
+

--- a/geshi/bascomavr.php
+++ b/geshi/bascomavr.php
@@ -182,4 +182,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/bash.php
+++ b/geshi/bash.php
@@ -471,4 +471,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/bf.php
+++ b/geshi/bf.php
@@ -112,4 +112,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/bibtex.php
+++ b/geshi/bibtex.php
@@ -180,4 +180,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/bnf.php
+++ b/geshi/bnf.php
@@ -116,4 +116,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/c.php
+++ b/geshi/c.php
@@ -278,4 +278,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/c_loadrunner.php
+++ b/geshi/c_loadrunner.php
@@ -320,4 +320,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/c_mac.php
+++ b/geshi/c_mac.php
@@ -224,4 +224,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/cfm.php
+++ b/geshi/cfm.php
@@ -296,4 +296,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/chaiscript.php
+++ b/geshi/chaiscript.php
@@ -137,4 +137,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/clojure.php
+++ b/geshi/clojure.php
@@ -131,4 +131,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/cmake.php
+++ b/geshi/cmake.php
@@ -178,4 +178,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/coffeescript.php
+++ b/geshi/coffeescript.php
@@ -143,4 +143,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/cpp-qt.php
+++ b/geshi/cpp-qt.php
@@ -567,4 +567,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/cpp.php
+++ b/geshi/cpp.php
@@ -243,4 +243,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/csharp.php
+++ b/geshi/csharp.php
@@ -256,4 +256,4 @@ $language_data = array (
     )
 );
 
-?>
+

--- a/geshi/css.php
+++ b/geshi/css.php
@@ -223,4 +223,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/cuesheet.php
+++ b/geshi/cuesheet.php
@@ -135,4 +135,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/d.php
+++ b/geshi/d.php
@@ -249,4 +249,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/dcl.php
+++ b/geshi/dcl.php
@@ -189,4 +189,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/dcpu16.php
+++ b/geshi/dcpu16.php
@@ -128,4 +128,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/dcs.php
+++ b/geshi/dcs.php
@@ -179,4 +179,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/diff.php
+++ b/geshi/diff.php
@@ -193,4 +193,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/dos.php
+++ b/geshi/dos.php
@@ -224,4 +224,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/dot.php
+++ b/geshi/dot.php
@@ -161,4 +161,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/e.php
+++ b/geshi/e.php
@@ -205,4 +205,3 @@ $language_data = array(
     'HIGHLIGHT_STRICT_BLOCK' => array()
 );
 
-?>

--- a/geshi/ecmascript.php
+++ b/geshi/ecmascript.php
@@ -207,4 +207,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/email.php
+++ b/geshi/email.php
@@ -219,4 +219,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/epc.php
+++ b/geshi/epc.php
@@ -151,4 +151,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/erlang.php
+++ b/geshi/erlang.php
@@ -438,4 +438,3 @@ $language_data = array(
     ),
 );
 
-?>

--- a/geshi/euphoria.php
+++ b/geshi/euphoria.php
@@ -137,4 +137,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/f1.php
+++ b/geshi/f1.php
@@ -148,4 +148,3 @@ $language_data = array(
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/falcon.php
+++ b/geshi/falcon.php
@@ -215,4 +215,3 @@ $language_data = array (
         '.'
     )
 );
-?>

--- a/geshi/fo.php
+++ b/geshi/fo.php
@@ -324,4 +324,3 @@ $language_data = array (
     'HIGHLIGHT_STRICT_BLOCK' => array(
         )
 );
-?>

--- a/geshi/fsharp.php
+++ b/geshi/fsharp.php
@@ -210,4 +210,3 @@ $language_data = array(
     )
 );
 
-?>

--- a/geshi/gambas.php
+++ b/geshi/gambas.php
@@ -211,4 +211,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/glsl.php
+++ b/geshi/glsl.php
@@ -202,4 +202,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/gnuplot.php
+++ b/geshi/gnuplot.php
@@ -293,4 +293,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/go.php
+++ b/geshi/go.php
@@ -372,4 +372,3 @@ $language_data = array(
         )
 );
 
-?>

--- a/geshi/groovy.php
+++ b/geshi/groovy.php
@@ -1008,4 +1008,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/gwbasic.php
+++ b/geshi/gwbasic.php
@@ -150,4 +150,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/haskell.php
+++ b/geshi/haskell.php
@@ -199,4 +199,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/haxe.php
+++ b/geshi/haxe.php
@@ -158,4 +158,3 @@ $language_data = array (
         ),
 );
 
-?>

--- a/geshi/hicest.php
+++ b/geshi/hicest.php
@@ -105,4 +105,3 @@ $language_data = array(
     'HIGHLIGHT_STRICT_BLOCK' => array()
 );
 
-?>

--- a/geshi/html4strict.php
+++ b/geshi/html4strict.php
@@ -187,4 +187,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/html5.php
+++ b/geshi/html5.php
@@ -209,4 +209,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/icon.php
+++ b/geshi/icon.php
@@ -209,4 +209,3 @@ $language_data = array(
         )
 );
 
-?>

--- a/geshi/intercal.php
+++ b/geshi/intercal.php
@@ -119,4 +119,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/javascript.php
+++ b/geshi/javascript.php
@@ -171,4 +171,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/jquery.php
+++ b/geshi/jquery.php
@@ -235,4 +235,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/latex.php
+++ b/geshi/latex.php
@@ -220,4 +220,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/lb.php
+++ b/geshi/lb.php
@@ -159,4 +159,3 @@ $language_data = array(
         )
 );
 
-?>

--- a/geshi/ldif.php
+++ b/geshi/ldif.php
@@ -113,4 +113,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/llvm.php
+++ b/geshi/llvm.php
@@ -382,4 +382,3 @@ $language_data = array(
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/locobasic.php
+++ b/geshi/locobasic.php
@@ -127,4 +127,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/logtalk.php
+++ b/geshi/logtalk.php
@@ -342,4 +342,3 @@ $language_data = array(
     ),
 );
 
-?>

--- a/geshi/lolcode.php
+++ b/geshi/lolcode.php
@@ -149,4 +149,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/lscript.php
+++ b/geshi/lscript.php
@@ -384,4 +384,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/magiksf.php
+++ b/geshi/magiksf.php
@@ -190,4 +190,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/make.php
+++ b/geshi/make.php
@@ -148,4 +148,4 @@ $language_data = array (
     'TAB_WIDTH' => 8
 // vim: set sw=4 sts=4 :
 );
-?>
+

--- a/geshi/mapbasic.php
+++ b/geshi/mapbasic.php
@@ -905,4 +905,3 @@ $language_data = array (
         ),
 );
 
-?>

--- a/geshi/matlab.php
+++ b/geshi/matlab.php
@@ -224,4 +224,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/mirc.php
+++ b/geshi/mirc.php
@@ -168,4 +168,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/mmix.php
+++ b/geshi/mmix.php
@@ -190,4 +190,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/modula2.php
+++ b/geshi/modula2.php
@@ -133,4 +133,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/modula3.php
+++ b/geshi/modula3.php
@@ -132,4 +132,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/mysql.php
+++ b/geshi/mysql.php
@@ -472,4 +472,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/newlisp.php
+++ b/geshi/newlisp.php
@@ -188,4 +188,3 @@ $language_data = array (
 
 );
 
-?>

--- a/geshi/oberon2.php
+++ b/geshi/oberon2.php
@@ -132,4 +132,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/objeck.php
+++ b/geshi/objeck.php
@@ -113,4 +113,3 @@ $language_data = array(
     'HIGHLIGHT_STRICT_BLOCK' => array()
 );
 
-?>

--- a/geshi/ocaml.php
+++ b/geshi/ocaml.php
@@ -184,4 +184,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/oxygene.php
+++ b/geshi/oxygene.php
@@ -151,4 +151,3 @@ $language_data = array (
     'TAB_WIDTH' => 2
 );
 
-?>

--- a/geshi/oz.php
+++ b/geshi/oz.php
@@ -141,4 +141,3 @@ $language_data = array(
         )
 );
 
-?>

--- a/geshi/parasail.php
+++ b/geshi/parasail.php
@@ -130,4 +130,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/pascal.php
+++ b/geshi/pascal.php
@@ -162,4 +162,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/pcre.php
+++ b/geshi/pcre.php
@@ -185,4 +185,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/perl.php
+++ b/geshi/perl.php
@@ -216,4 +216,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/perl6.php
+++ b/geshi/perl6.php
@@ -194,4 +194,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/pf.php
+++ b/geshi/pf.php
@@ -175,4 +175,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/php-brief.php
+++ b/geshi/php-brief.php
@@ -219,4 +219,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/pli.php
+++ b/geshi/pli.php
@@ -197,4 +197,3 @@ $language_data = array(
     'HIGHLIGHT_STRICT_BLOCK' => array()
 );
 
-?>

--- a/geshi/postgresql.php
+++ b/geshi/postgresql.php
@@ -285,4 +285,3 @@ $language_data = array (
 
 );
 
-?>

--- a/geshi/povray.php
+++ b/geshi/povray.php
@@ -196,4 +196,4 @@ $language_data = array (
         ),
     'TAB_WIDTH' => 4
 );
-?>
+

--- a/geshi/powerbuilder.php
+++ b/geshi/powerbuilder.php
@@ -415,4 +415,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/powershell.php
+++ b/geshi/powershell.php
@@ -274,4 +274,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/proftpd.php
+++ b/geshi/proftpd.php
@@ -371,4 +371,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/progress.php
+++ b/geshi/progress.php
@@ -482,4 +482,3 @@ $language_data = array(
         )
 );
 
-?>

--- a/geshi/prolog.php
+++ b/geshi/prolog.php
@@ -140,4 +140,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/properties.php
+++ b/geshi/properties.php
@@ -124,4 +124,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/purebasic.php
+++ b/geshi/purebasic.php
@@ -300,4 +300,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/pycon.php
+++ b/geshi/pycon.php
@@ -61,4 +61,3 @@ if(!isset($language_data['COMMENT_REGEXP'])) {
 $language_data['COMMENT_REGEXP'][-1] = '/(?:^|\A\s)(?:>>>|\.\.\.)/m';
 $language_data['STYLES']['COMMENTS'][-1] = 'color: #444444;';
 
-?>

--- a/geshi/python.php
+++ b/geshi/python.php
@@ -241,4 +241,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/q.php
+++ b/geshi/q.php
@@ -146,4 +146,3 @@ $language_data = array (
         ),
 );
 
-?>

--- a/geshi/qbasic.php
+++ b/geshi/qbasic.php
@@ -159,4 +159,3 @@ $language_data = array (
     'TAB_WIDTH' => 8
 );
 
-?>

--- a/geshi/rebol.php
+++ b/geshi/rebol.php
@@ -193,4 +193,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/robots.php
+++ b/geshi/robots.php
@@ -97,4 +97,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/rpmspec.php
+++ b/geshi/rpmspec.php
@@ -130,4 +130,3 @@ $language_data = array (
     'SCRIPT_DELIMITERS' => array(),
 );
 
-?>

--- a/geshi/rsplus.php
+++ b/geshi/rsplus.php
@@ -480,4 +480,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/ruby.php
+++ b/geshi/ruby.php
@@ -228,4 +228,3 @@ $language_data = array (
     'TAB_WIDTH' => 2
 );
 
-?>

--- a/geshi/sas.php
+++ b/geshi/sas.php
@@ -287,4 +287,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/scala.php
+++ b/geshi/scala.php
@@ -135,4 +135,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/scilab.php
+++ b/geshi/scilab.php
@@ -292,4 +292,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/smalltalk.php
+++ b/geshi/smalltalk.php
@@ -151,4 +151,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/spark.php
+++ b/geshi/spark.php
@@ -129,4 +129,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/sparql.php
+++ b/geshi/sparql.php
@@ -152,4 +152,3 @@ $language_data = array (
     'HIGHLIGHT_STRICT_BLOCK' => array()
 );
 
-?>

--- a/geshi/sql.php
+++ b/geshi/sql.php
@@ -167,4 +167,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/stonescript.php
+++ b/geshi/stonescript.php
@@ -304,4 +304,3 @@ $language_data = array (
     'TAB_WIDTH' => 2
 );
 
-?>

--- a/geshi/systemverilog.php
+++ b/geshi/systemverilog.php
@@ -314,4 +314,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/tcl.php
+++ b/geshi/tcl.php
@@ -191,4 +191,3 @@ $language_data = array (
     )
 );
 
-?>

--- a/geshi/teraterm.php
+++ b/geshi/teraterm.php
@@ -351,4 +351,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/tsql.php
+++ b/geshi/tsql.php
@@ -372,4 +372,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/unicon.php
+++ b/geshi/unicon.php
@@ -207,4 +207,3 @@ $language_data = array(
         )
 );
 
-?>

--- a/geshi/upc.php
+++ b/geshi/upc.php
@@ -267,4 +267,3 @@ $language_data = array (
     'TAB_WIDTH' => 4
 );
 
-?>

--- a/geshi/vb.php
+++ b/geshi/vb.php
@@ -154,4 +154,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/vbnet.php
+++ b/geshi/vbnet.php
@@ -179,4 +179,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/vedit.php
+++ b/geshi/vedit.php
@@ -100,4 +100,3 @@ $language_data = array(
     'HIGHLIGHT_STRICT_BLOCK' => array()
 );
 
-?>

--- a/geshi/visualfoxpro.php
+++ b/geshi/visualfoxpro.php
@@ -453,4 +453,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/whois.php
+++ b/geshi/whois.php
@@ -178,4 +178,3 @@ $language_data = array (
         ),
 );
 
-?>

--- a/geshi/winbatch.php
+++ b/geshi/winbatch.php
@@ -366,4 +366,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/xbasic.php
+++ b/geshi/xbasic.php
@@ -2,8 +2,8 @@
 /*************************************************************************************
  * xbasic.php
  * ----------
- * Author: José Gabriel Moya Yangüela (josemoya@gmail.com)
- * Copyright: (c) 2005 José Gabriel Moya Yangüela (http://aprenderadesaprender.6te.net)
+ * Author: JosÃ© Gabriel Moya YangÃ¼ela (josemoya@gmail.com)
+ * Copyright: (c) 2005 JosÃ© Gabriel Moya YangÃ¼ela (http://aprenderadesaprender.6te.net)
  * Release Version: 1.0.8.11
  * Date Started: 2005/11/23
  *
@@ -140,4 +140,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/xojo.php
+++ b/geshi/xojo.php
@@ -163,4 +163,3 @@ $language_data = array (
         )
 );
 
-?>

--- a/geshi/yaml.php
+++ b/geshi/yaml.php
@@ -147,4 +147,3 @@ $language_data = array (
     'HIGHLIGHT_STRICT_BLOCK' => array( )
 );
 
-?>

--- a/geshi/z80.php
+++ b/geshi/z80.php
@@ -141,4 +141,3 @@ $language_data = array (
     'TAB_WIDTH' => 8
 );
 
-?>

--- a/geshi/zxbasic.php
+++ b/geshi/zxbasic.php
@@ -147,4 +147,3 @@ $language_data = array (
         )
 );
 
-?>


### PR DESCRIPTION
Nowadays the php closing tag is not necessary any more and should be removed. See PSR recommendations and results of builtin code inspection tools in IDEs like PhpStorm and others…