### PR TITLE
Fixed QUOTEMARKS for Haskell

### DIFF
--- a/geshi/haskell.php
+++ b/geshi/haskell.php
@@ -46,7 +46,7 @@ $language_data = array (
         3 => "/{-(?:(?R)|.)-}/s", //Nested Comments
         ),
     'CASE_KEYWORDS' => 0,
-    'QUOTEMARKS' => array('"',"'"),
+    'QUOTEMARKS' => array('"'),
     'ESCAPE_CHAR' => '\\',
     'KEYWORDS' => array(
         /* main haskell keywords */


### PR DESCRIPTION
The symbol (') is not used for Haskell string literals, but is used in the names almost as a regular character. Including the names of functions in the base package, and other commonly used packs.

https://www.haskell.org/onlinereport/haskell2010/haskellch2.html#x7-180002.4  Sections 2.4, 2.6